### PR TITLE
Some reporter/heroku cleanups

### DIFF
--- a/reporter/heroku_test.go
+++ b/reporter/heroku_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestReporterLoopCancel(t *testing.T) {
 	inbox := make(chan *am.Measurement, 1)
-	config := HerokuConfig{Interval: time.Duration(1)}
-	reporter := HerokuReporter{config, inbox}
+	reporter := Heroku{Interval: time.Duration(1), Inbox: inbox}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Redirect logging temporarily
@@ -25,7 +24,7 @@ func TestReporterLoopCancel(t *testing.T) {
 
 	// Cancel before loop starts
 	cancel()
-	go reporter.reportLoop(ctx)
+	go reporter.Report(ctx)
 
 	// Populate lines from log into a channel.
 	lines := make(chan string, 10)


### PR DESCRIPTION
Some suggestions, happy to discuss.

* Move HEROKU_METRICS_URL out of the reporter into main.
* collapse the heroku reporter config down into the Heroku struct
* Remove some extraneous log.Fatal formatting.
* Make Heroku.Report() syncronous, allowing the caller to determine
  if it should be async or not.
* Don't stutter s/reporter.HerokuReporter/reporter.Heroku/
* Add some comments to the exported methods/structs to silence lint