### PR TITLE
Clean up logging a bit

### DIFF
--- a/cmd/agentmon/main.go
+++ b/cmd/agentmon/main.go
@@ -31,6 +31,9 @@ var (
 const measurementBufferSize = 1000
 
 func main() {
+	log.SetPrefix("agentmon: ")
+	log.SetFlags(0)
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: %s [flags] sink-URL", os.Args[0])
 	}


### PR DESCRIPTION
Prefix agentmon logs with "agentmon: " and don't include the time
or date since it's included by heroku's logs