### PR TITLE
Summary counter compute deriv

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -62,7 +62,14 @@ func (ms *MeasurementSet) Update(m *Measurement) {
 			}
 		}
 
-		ms.Gauges[m.Name] += val * (1 / float64(m.Sample))
+		switch m.Modifier {
+		case "+":
+			ms.Gauges[m.Name] = prev + val
+		case "-":
+			ms.Gauges[m.Name] = prev - val
+		default:
+			ms.Gauges[m.Name] += val * (1 / float64(m.Sample))
+		}
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -75,14 +75,18 @@ func (ms *MeasurementSet) Update(m *Measurement) {
 
 func (ms *MeasurementSet) Snapshot() *MeasurementSet {
 	out := &MeasurementSet{
-		Counters: make(map[string]float64),
-		Gauges:   make(map[string]float64),
+		Counters:     make(map[string]float64),
+		Gauges:       make(map[string]float64),
+		monoCounters: make(map[string]float64),
 	}
 	for k, v := range ms.Counters {
 		out.Counters[k] = v
 	}
 	for k, v := range ms.Gauges {
 		out.Gauges[k] = v
+	}
+	for k, v := range ms.monoCounters {
+		out.monoCounters[k] = v
 	}
 
 	return out

--- a/metrics.go
+++ b/metrics.go
@@ -62,13 +62,15 @@ func (ms *MeasurementSet) Update(m *Measurement) {
 			}
 		}
 
+		val *= (1 / float64(m.Sample))
+
 		switch m.Modifier {
 		case "+":
 			ms.Gauges[m.Name] = prev + val
 		case "-":
 			ms.Gauges[m.Name] = prev - val
 		default:
-			ms.Gauges[m.Name] += val * (1 / float64(m.Sample))
+			ms.Gauges[m.Name] += val
 		}
 	}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -2,10 +2,21 @@ package agentmon
 
 import "time"
 
+type MetricType int
+
+const (
+	Counter MetricType = iota
+	DerivedCounter
+	Gauge
+
+	// Currently unused, except in statsd parsing.
+	Timer
+)
+
 type Measurement struct {
 	Name      string
 	Timestamp time.Time
-	Type      string
+	Type      MetricType
 	Value     float64
 	Sample    float32
 	Modifier  string
@@ -25,10 +36,11 @@ func NewMeasurementSet() *MeasurementSet {
 
 func (ms *MeasurementSet) Update(m *Measurement) {
 	switch m.Type {
-	case "c":
+	case Counter:
 		ms.Counters[m.Name] += m.Value * (1 / float64(m.Sample))
-	case "g":
-		ms.Gauges[m.Name] += m.Value * (1 / float64(m.Sample))
+
+	case DerivedCounter:
+	case Gauge:
 	}
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -55,9 +55,9 @@ func (ms *MeasurementSet) Update(m *Measurement) {
 
 		val := current / float64(m.Sample)
 		if current < prev { // A reset has occurred
-			ms.Counters[m.Name] = val
+			ms.Counters[m.Name] += val
 		} else {
-			ms.Counters[m.Name] = val - prev
+			ms.Counters[m.Name] += val - prev
 		}
 
 	case Gauge:

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,225 @@
+package agentmon
+
+import (
+	"testing"
+	"time"
+)
+
+type event struct {
+	m    Measurement
+	want float64
+}
+
+func driveTest(t *testing.T, events []event) {
+	underTest := NewMeasurementSet(nil)
+	for i, e := range events {
+		underTest.Update(&(e.m))
+		var got float64
+		switch e.m.Type {
+		case Counter, DerivedCounter:
+			got = underTest.Counters[e.m.Name]
+		default:
+			got = underTest.Gauges[e.m.Name]
+		}
+
+		if got != e.want {
+			t.Errorf("after event %d: got %f, want %f", i+1, got, e.want)
+		}
+
+		underTest = NewMeasurementSet(underTest.Snapshot())
+	}
+}
+
+func TestCounters(t *testing.T) {
+	events := []event{
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Counter,
+				Value:     3.0,
+				Sample:    1.0,
+			},
+			want: 3.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Counter,
+				Value:     9.0,
+				Sample:    1.0,
+			},
+			want: 9.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Counter,
+				Value:     3.0,
+				Sample:    0.5,
+			},
+			want: 6.0,
+		},
+	}
+
+	driveTest(t, events)
+}
+
+func TestDerivedCounters(t *testing.T) {
+	events := []event{
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      DerivedCounter,
+				Value:     1.0,
+				Sample:    1.0,
+			},
+			want: 1.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      DerivedCounter,
+				Value:     3.0,
+				Sample:    1.0,
+			},
+			want: 2.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      DerivedCounter,
+				Value:     8.0,
+				Sample:    1.0,
+			},
+			want: 5.0,
+		},
+	}
+
+	driveTest(t, events)
+
+}
+
+func TestGauges(t *testing.T) {
+	events := []event{
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Gauge,
+				Value:     1.0,
+				Sample:    0.5,
+			},
+			want: 2.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Gauge,
+				Value:     3.0,
+				Sample:    1.0,
+			},
+			want: 3.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Gauge,
+				Value:     8.0,
+				Sample:    1.0,
+			},
+			want: 8.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Gauge,
+				Value:     8.0,
+				Sample:    1.0,
+				Modifier:  "+",
+			},
+			want: 16.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      Gauge,
+				Value:     8.0,
+				Sample:    1.0,
+				Modifier:  "-",
+			},
+			want: 8.0,
+		},
+	}
+
+	driveTest(t, events)
+}
+
+func TestMeasurementSetLen(t *testing.T) {
+	underTest := NewMeasurementSet(nil)
+	underTest.Update(&Measurement{
+		Name:      "foo.bar",
+		Timestamp: time.Now(),
+		Type:      Counter,
+		Value:     3.0,
+		Sample:    1.0,
+	})
+
+	underTest.Update(&Measurement{
+		Name:      "foo.baz",
+		Timestamp: time.Now(),
+		Type:      Counter,
+		Value:     5.0,
+		Sample:    1.0,
+	})
+
+	if underTest.Len() != 2 {
+		t.Errorf("got %d, want 2", underTest.Len())
+	}
+}
+
+func TestMeasurementSetSnapshot(t *testing.T) {
+	underTest := NewMeasurementSet(nil)
+	underTest.Update(&Measurement{
+		Name:      "foo.bar",
+		Timestamp: time.Now(),
+		Type:      Counter,
+		Value:     3.0,
+		Sample:    1.0,
+	})
+
+	underTest.Update(&Measurement{
+		Name:      "foo.baz",
+		Timestamp: time.Now(),
+		Type:      Counter,
+		Value:     5.0,
+		Sample:    1.0,
+	})
+
+	snap := underTest.Snapshot()
+
+	underTest.Update(&Measurement{
+		Name:      "foo.baz",
+		Timestamp: time.Now(),
+		Type:      Counter,
+		Value:     20.0,
+		Sample:    1.0,
+	})
+
+	snapBaz := snap.Counters["foo.baz"]
+	origBaz := underTest.Counters["foo.baz"]
+
+	if snapBaz == origBaz {
+		t.Errorf("snapshot should not reflect updates to it's parent: snap = %f, orig = %f", snapBaz, origBaz)
+	}
+
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -102,7 +102,43 @@ func TestDerivedCounters(t *testing.T) {
 	}
 
 	driveTest(t, events)
+}
 
+func TestDerivedCountersWithRest(t *testing.T) {
+	events := []event{
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      DerivedCounter,
+				Value:     1.0,
+				Sample:    1.0,
+			},
+			want: 1.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      DerivedCounter,
+				Value:     8.0,
+				Sample:    1.0,
+			},
+			want: 7.0,
+		},
+		{
+			m: Measurement{
+				Name:      "foo.bar",
+				Timestamp: time.Now(),
+				Type:      DerivedCounter,
+				Value:     3.0,
+				Sample:    1.0,
+			},
+			want: 3.0,
+		},
+	}
+
+	driveTest(t, events)
 }
 
 func TestGauges(t *testing.T) {

--- a/prom/poller.go
+++ b/prom/poller.go
@@ -158,7 +158,7 @@ func familyToMeasurements(mf *dto.MetricFamily) (out []*ag.Measurement, ok bool)
 			out = append(out, &ag.Measurement{
 				Name:      name + suffixFor(m),
 				Timestamp: msToTime(m.GetTimestampMs()),
-				Type:      "g",
+				Type:      ag.Gauge,
 				Value:     getValue(m),
 				Sample:    1.0,
 			})
@@ -169,7 +169,7 @@ func familyToMeasurements(mf *dto.MetricFamily) (out []*ag.Measurement, ok bool)
 			out = append(out, &ag.Measurement{
 				Name:      name + suffixFor(m),
 				Timestamp: msToTime(m.GetTimestampMs()),
-				Type:      "c",
+				Type:      ag.DerivedCounter,
 				Value:     getValue(m),
 				Sample:    1.0,
 			})
@@ -181,14 +181,14 @@ func familyToMeasurements(mf *dto.MetricFamily) (out []*ag.Measurement, ok bool)
 			out = append(out, &ag.Measurement{
 				Name:      name + suffixFor(m),
 				Timestamp: msToTime(m.GetTimestampMs()),
-				Type:      "g",
+				Type:      ag.DerivedCounter,
 				Value:     summary.GetSampleSum(),
 				Sample:    1.0,
 			})
 			out = append(out, &ag.Measurement{
 				Name:      name + suffixFor(m),
 				Timestamp: msToTime(m.GetTimestampMs()),
-				Type:      "c",
+				Type:      ag.DerivedCounter,
 				Value:     float64(summary.GetSampleCount()),
 				Sample:    1.0,
 			})

--- a/prom/poller.go
+++ b/prom/poller.go
@@ -179,14 +179,14 @@ func familyToMeasurements(mf *dto.MetricFamily) (out []*ag.Measurement, ok bool)
 		for _, m := range mf.Metric {
 			summary := m.GetSummary()
 			out = append(out, &ag.Measurement{
-				Name:      name + suffixFor(m),
+				Name:      name + "_sum" + suffixFor(m),
 				Timestamp: msToTime(m.GetTimestampMs()),
 				Type:      ag.DerivedCounter,
 				Value:     summary.GetSampleSum(),
 				Sample:    1.0,
 			})
 			out = append(out, &ag.Measurement{
-				Name:      name + suffixFor(m),
+				Name:      name + "_count" + suffixFor(m),
 				Timestamp: msToTime(m.GetTimestampMs()),
 				Type:      ag.DerivedCounter,
 				Value:     float64(summary.GetSampleCount()),

--- a/prom/poller_test.go
+++ b/prom/poller_test.go
@@ -144,12 +144,12 @@ func fakeSummaryFamily() (*dto.MetricFamily, []*am.Measurement) {
 			},
 		}, []*am.Measurement{
 			{
-				Name:  "some_summary.path_index",
+				Name:  "some_summary_sum.path_index",
 				Value: 20,
 				Type:  am.DerivedCounter,
 			},
 			{
-				Name:  "some_summary.path_index",
+				Name:  "some_summary_count.path_index",
 				Value: 2,
 				Type:  am.DerivedCounter,
 			},

--- a/prom/poller_test.go
+++ b/prom/poller_test.go
@@ -146,12 +146,12 @@ func fakeSummaryFamily() (*dto.MetricFamily, []*am.Measurement) {
 			{
 				Name:  "some_summary.path_index",
 				Value: 20,
-				Type:  "g",
+				Type:  am.DerivedCounter,
 			},
 			{
 				Name:  "some_summary.path_index",
 				Value: 2,
-				Type:  "c",
+				Type:  am.DerivedCounter,
 			},
 		}
 }
@@ -219,12 +219,12 @@ func fakeCounterFamily() (*dto.MetricFamily, []*am.Measurement) {
 			{
 				Name:  "some_counter.code_200.type_http",
 				Value: 1,
-				Type:  "c",
+				Type:  am.DerivedCounter,
 			},
 			{
 				Name:  "some_counter.code_500.type_http",
 				Value: 1,
-				Type:  "c",
+				Type:  am.DerivedCounter,
 			},
 		}
 

--- a/reporter/heroku.go
+++ b/reporter/heroku.go
@@ -33,7 +33,8 @@ func (r Heroku) Report(ctx context.Context) {
 		r.Interval = defaultHerokuReporterInterval
 	}
 
-	measurements := am.NewMeasurementSet()
+	var oldSet *am.MeasurementSet
+	currentSet := am.NewMeasurementSet(oldSet)
 	ticks := time.Tick(r.Interval)
 
 	for {
@@ -44,12 +45,12 @@ func (r Heroku) Report(ctx context.Context) {
 			}
 			return
 		case m := <-r.Inbox:
-			measurements.Update(m)
+			currentSet.Update(m)
 		case <-ticks:
-			out := measurements
-			measurements = am.NewMeasurementSet()
-
-			go r.flush(ctx, out)
+			flushSet := currentSet.Snapshot()
+			oldSet = currentSet
+			currentSet = am.NewMeasurementSet(oldSet)
+			go r.flush(ctx, flushSet)
 		}
 	}
 }

--- a/reporter/heroku.go
+++ b/reporter/heroku.go
@@ -33,8 +33,7 @@ func (r Heroku) Report(ctx context.Context) {
 		r.Interval = defaultHerokuReporterInterval
 	}
 
-	var oldSet *am.MeasurementSet
-	currentSet := am.NewMeasurementSet(oldSet)
+	currentSet := am.NewMeasurementSet(nil)
 	ticks := time.Tick(r.Interval)
 
 	for {
@@ -48,8 +47,7 @@ func (r Heroku) Report(ctx context.Context) {
 			currentSet.Update(m)
 		case <-ticks:
 			flushSet := currentSet.Snapshot()
-			oldSet = currentSet
-			currentSet = am.NewMeasurementSet(oldSet)
+			currentSet = am.NewMeasurementSet(flushSet)
 			go r.flush(ctx, flushSet)
 		}
 	}

--- a/statsd/listener_test.go
+++ b/statsd/listener_test.go
@@ -35,17 +35,17 @@ gaugor:333|g
 		&am.Measurement{
 			Name:  "gorets",
 			Value: 1.0,
-			Type:  "c",
+			Type:  am.Counter,
 		},
 		&am.Measurement{
 			Name:  "gorets",
 			Value: 1.0,
-			Type:  "c",
+			Type:  am.Counter,
 		},
 		&am.Measurement{
 			Name:  "gaugor",
 			Value: 333.0,
-			Type:  "g",
+			Type:  am.Gauge,
 		},
 	}
 

--- a/statsd/parser.go
+++ b/statsd/parser.go
@@ -183,7 +183,7 @@ func (p *Parser) parseLine(line []byte) (*agentmon.Measurement, error) {
 	out := &agentmon.Measurement{
 		Name:      string(name),
 		Timestamp: time.Now(),
-		Type:      string(measureType),
+		Type:      stringToMetricType(string(measureType)),
 		Value:     value,
 		Sample:    sample,
 	}
@@ -193,6 +193,17 @@ func (p *Parser) parseLine(line []byte) (*agentmon.Measurement, error) {
 	}
 
 	return out, nil
+}
+
+func stringToMetricType(s string) agentmon.MetricType {
+	switch s {
+	case "c":
+		return agentmon.Counter
+	case "ms":
+		return agentmon.Timer
+	default:
+		return agentmon.Gauge
+	}
 }
 
 func readMetricName(buf []byte) ([]byte, []byte, error) {

--- a/statsd/parser_test.go
+++ b/statsd/parser_test.go
@@ -43,17 +43,17 @@ gaugor:333|g
 		&am.Measurement{
 			Name:  "gorets",
 			Value: 1.0,
-			Type:  "c",
+			Type:  am.Counter,
 		},
 		&am.Measurement{
 			Name:  "gorets",
 			Value: 1.0,
-			Type:  "c",
+			Type:  am.Counter,
 		},
 		&am.Measurement{
 			Name:  "gaugor",
 			Value: 333.0,
-			Type:  "g",
+			Type:  am.Gauge,
 		},
 	}
 
@@ -72,17 +72,17 @@ gaugor:333|g
 		&am.Measurement{
 			Name:  "gorets",
 			Value: 1.0,
-			Type:  "c",
+			Type:  am.Counter,
 		},
 		&am.Measurement{
 			Name:  "gorets",
 			Value: 1.0,
-			Type:  "c",
+			Type:  am.Counter,
 		},
 		&am.Measurement{
 			Name:  "gaugor",
 			Value: 333.0,
-			Type:  "g",
+			Type:  am.Gauge,
 		},
 	}
 
@@ -98,14 +98,14 @@ func TestParse(t *testing.T) {
 				Name:     "gorets",
 				Value:    1.0,
 				Sample:   1.0,
-				Type:     "c",
+				Type:     am.Counter,
 				Modifier: "",
 			},
 			"gorets:1|c|@0.1": &am.Measurement{
 				Name:     "gorets",
 				Value:    1.0,
 				Sample:   0.1,
-				Type:     "c",
+				Type:     am.Counter,
 				Modifier: "",
 			},
 		},
@@ -114,21 +114,21 @@ func TestParse(t *testing.T) {
 				Name:     "gaugor",
 				Value:    333,
 				Sample:   1.0,
-				Type:     "g",
+				Type:     am.Gauge,
 				Modifier: "",
 			},
 			"gaugor:+4.4|g": &am.Measurement{
 				Name:     "gaugor",
 				Value:    4.4,
 				Sample:   1.0,
-				Type:     "g",
+				Type:     am.Gauge,
 				Modifier: "+",
 			},
 			"gaugor:-14.2|g": &am.Measurement{
 				Name:     "gaugor",
 				Value:    14.2,
 				Sample:   1.0,
-				Type:     "g",
+				Type:     am.Gauge,
 				Modifier: "-",
 			},
 		},
@@ -137,7 +137,7 @@ func TestParse(t *testing.T) {
 				Name:     "glork",
 				Value:    320.0,
 				Sample:   0.1,
-				Type:     "ms",
+				Type:     am.Timer,
 				Modifier: "",
 			},
 		},


### PR DESCRIPTION
Among various improvements to testing, etc, this introduces a `DerivedCounter`, which is then used for counters and summaries coming from Prometheus. This plants us to the statsd version of counters, which can actually be described as the derivative of a monotonically increasing value between lastFlush and current. In our case, it's not lastFlush so much as lastPoll, when speaking about the Prometheus poller.

But, it connects to #7 

Note: This adds back the names "_sum" and "_count" for Prometheus Summary metrics. The reasoning for this is both the sum and count values returned via a Summary behave like counters, and therefore are tracked like counters. There are some caveats here, in that it's possible that the total will go down, making the total non-monotonically increasing, according to the documentation. 