### PR TITLE
Makefile: remove gox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 LINKER_VERSION_SYMBOL := github.com/heroku/agentmon.VERSION
 LINKER_VERSION := $(shell git describe --tags --always)
-ARCHES := linux/amd64
 
 build:
 	go build -a -ldflags "-X ${LINKER_VERSION_SYMBOL}=${LINKER_VERSION}" ./cmd/agentmon
@@ -8,14 +7,13 @@ build:
 install:
 	go install -a -ldflags "-X ${LINKER_VERSION_SYMBOL} ${LINKER_VERSION}" ./...
 
-release: gox
+release:
 	{\
-		TMP=$$(mktemp -d -t agentmon.XXXXX); \
-		for arch in $(ARCHES); do \
-			gox -osarch="$$arch" -output="$$TMP/{{.OS}}/{{.Arch}}/{{.Dir}}" -ldflags "-X $(LINKER_VERSION_SYMBOL)=$(LINKER_VERSION)" ./...; \
-			tar -C $$TMP/$$arch -czf "agentmon-$(LINKER_VERSION)-$$(echo $$arch | sed 's;/;-;').tar.gz" .; \
-		done; \
-		rm -rf $$TMP; \
+		export GOOS=linux; \
+		export GOARCH=amd64; \
+		go build -ldflags "-X $(LINKER_VERSION_SYMBOL)=$(LINKER_VERSION)" -o agentmon ./cmd/agentmon; \
+		tar czf "agentmon-$(LINKER_VERSION)-$$(echo $$GOOS-$$GOARCH | sed 's;/;-;').tar.gz" agentmon; \
+		rm -rf agentmon; \
 	}
 
 test:
@@ -23,6 +21,3 @@ test:
 
 bench:
 	go test -v -bench . ./...
-
-gox:
-	go get -u github.com/mitchellh/gox

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,11 @@ build:
 install:
 	go install -a -ldflags "-X ${LINKER_VERSION_SYMBOL} ${LINKER_VERSION}" ./...
 
+release: GOOS := linux
+release: GOARCH := amd64
 release:
-	{\
-		export GOOS=linux; \
-		export GOARCH=amd64; \
-		go build -ldflags "-X $(LINKER_VERSION_SYMBOL)=$(LINKER_VERSION)" -o agentmon ./cmd/agentmon; \
-		tar czf "agentmon-$(LINKER_VERSION)-$$(echo $$GOOS-$$GOARCH | sed 's;/;-;').tar.gz" agentmon; \
-		rm -rf agentmon; \
-	}
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-X $(LINKER_VERSION_SYMBOL)=$(LINKER_VERSION)" -o agentmon ./cmd/agentmon
+	tar czf "agentmon-$(LINKER_VERSION)-$(GOOS)-$(GOARCH).tar.gz" agentmon
 
 test:
 	CGO_ENABLED=1 go test -v -race ./...

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ release: GOARCH := amd64
 release:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-X $(LINKER_VERSION_SYMBOL)=$(LINKER_VERSION)" -o agentmon ./cmd/agentmon
 	tar czf "agentmon-$(LINKER_VERSION)-$(GOOS)-$(GOARCH).tar.gz" agentmon
+	rm agentmon
 
 test:
 	CGO_ENABLED=1 go test -v -race ./...


### PR DESCRIPTION
We're cross compiling a single binary for amd64 linux. Go lets you do that natively as of Go 1.5.

https://dave.cheney.net/2015/08/22/cross-compilation-with-go-1-5
https://golang.org/doc/go1.5#compiler_and_tools