### PR TITLE
Makefile: prefer GNU tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ install:
 
 release: GOOS := linux
 release: GOARCH := amd64
+release: PATH := /usr/local/opt/gnu-tar/libexec/gnubin:$(PATH)
 release:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-X $(LINKER_VERSION_SYMBOL)=$(LINKER_VERSION)" -o agentmon ./cmd/agentmon
 	tar czf "agentmon-$(LINKER_VERSION)-$(GOOS)-$(GOARCH).tar.gz" agentmon


### PR DESCRIPTION
On OSX the default `tar` is not GNU tar. In order to install GNU tar
on your system, run:

    $ brew install gnu-tar

This normally installs as `gtar`, but if you prepend to PATH like this:

    export PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"

`tar` now is gnu tar.

---

This prevents messages like the following from being logged on app boot:
```
2017-04-20T17:52:48.420791+00:00 app[web.1]: tar: Ignoring unknown extended header keyword 'SCHILY.dev'
2017-04-20T17:52:48.420796+00:00 app[web.1]: tar: Ignoring unknown extended header keyword 'SCHILY.ino'
2017-04-20T17:52:48.420797+00:00 app[web.1]: tar: Ignoring unknown extended header keyword 'SCHILY.nlink'
```