### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/bin/sync-files.sh
+++ b/bin/sync-files.sh
@@ -26,6 +26,6 @@ if [ ${#tools} -ne 0 ]; then
 fi
 
 ${S3CMD} put -P $1 ${BUCKET}
-echo "https://agentmon-releases.s3.amazonaws.com/$1" >> latest
+echo "https://agentmon-releases.s3.us-east-1.amazonaws.com/$1" >> latest
 ${S3CMD} put -P latest ${BUCKET}
 rm latest


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`: https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region